### PR TITLE
🌷Don't put state of the navbar on local storage

### DIFF
--- a/providers/global-state/index.js
+++ b/providers/global-state/index.js
@@ -1,10 +1,9 @@
-import { createContext } from "react"
-import useStickyState from "hooks/useStickyState"
+import { createContext, useState } from "react"
 
 const GlobalStateContext = createContext({})
 
 const GlobalStateProvider = ({ children }) => {
-    let [menuState, setMenuState] = useStickyState("none", "menuState")
+    let [menuState, setMenuState] = useState("none", "menuState")
 
     const changeMenuState = menuType => {
         // if menuType === "none": menuState = "none"


### PR DESCRIPTION
This is an attempt to remove the blue selection border on mobile.. and also fix the behavior of the navigation menu modals. 
In the first place, when a page is refreshed, the modal shouldn't STILL be open. 

The blu selection border is still not fixed on mobile... but with the responsive tool on the laptop web browser it is...

![IMG_0291](https://user-images.githubusercontent.com/1670421/105682096-f7787b00-5f2c-11eb-879b-503d180f2501.PNG)
