### PR TITLE
🐞 Fix #112: Right 'notes/disc' pane now scrolls to the top upon page switch

### DIFF
--- a/components/notebook/index.js
+++ b/components/notebook/index.js
@@ -1,5 +1,5 @@
 import dynamic from "next/dynamic"
-import { useMemo, useState } from "react"
+import { useMemo, useState, useEffect } from "react"
 import {
     FiGithub,
     BiRocket,
@@ -126,8 +126,9 @@ const PageLayout = ({
             <SquareButton href={KOFI_URL} {...bp.kofi} />
         </div>
     )
+
     const articlePlus = (
-        <>
+        <div id='currentArticlePlus'>
             {hasApp && callToActionBox}
             {hasApp && notebookPageButtons}
             <article>
@@ -142,7 +143,7 @@ const PageLayout = ({
             <div style={{ display: "flex", justifyContent: "center", margin: "20px" }}>
                 {notebookPageButtons}
             </div>
-        </>
+        </div>
     )
 
     const div1 = (
@@ -166,6 +167,10 @@ const PageLayout = ({
     )
 
     const div2 = hasApp && articlePlus
+
+    useEffect(() => {
+      document.getElementById('currentArticlePlus').scrollIntoView()
+    }, [div2])
 
     return (
         <Main>


### PR DESCRIPTION
**For reference:**

- https://stackoverflow.com/questions/33188994/scroll-to-the-top-of-the-page-after-render-in-react-js
- https://stackoverflow.com/questions/68165/javascript-to-scroll-long-page-to-div