### PR TITLE
🐞 Fix #116: Hide ugly scrollbars on Windows. (At least in Chrome)

### DIFF
--- a/components/main/Styles.module.css
+++ b/components/main/Styles.module.css
@@ -21,22 +21,22 @@
 }
 
 .common::-webkit-scrollbar {
-  width: 20px;
+    width: 20px;
 }
 
 .common::-webkit-scrollbar-track {
-  background-color: transparent;
+    background-color: transparent;
 }
 
 .common::-webkit-scrollbar-thumb {
-  background-color: #d6dee1;
-  border-radius: 20px;
-  border: 6px solid transparent;
-  background-clip: content-box;
+    background-color: rgba(214, 222, 225, 0.4);
+    border-radius: 20px;
+    border: 8px solid transparent;
+    background-clip: content-box;
 }
 
 .common::-webkit-scrollbar-thumb:hover {
-  background-color: #a8bbbf;
+    background-color: rgba(214, 222, 225, 0.4);
 }
 
 .div1 {
@@ -111,22 +111,22 @@
     }
 
     .main::-webkit-scrollbar {
-      width: 20px;
+        width: 20px;
     }
-    
+
     .main::-webkit-scrollbar-track {
-      background-color: transparent;
+        background-color: transparent;
     }
-    
+
     .main::-webkit-scrollbar-thumb {
-      background-color: #d6dee1;
-      border-radius: 20px;
-      border: 6px solid transparent;
-      background-clip: content-box;
+        background-color: rgba(214, 222, 225, 0.4);
+        border-radius: 20px;
+        border: 8px solid transparent;
+        background-clip: content-box;
     }
-    
+
     .main::-webkit-scrollbar-thumb:hover {
-      background-color: #a8bbbf;
+        background-color: rgba(214, 222, 225, 0.4);
     }
 
     .twoSectionsLayout {

--- a/components/main/Styles.module.css
+++ b/components/main/Styles.module.css
@@ -15,8 +15,28 @@
 }
 
 .common {
-    overflow: scroll;
+    overflow-y: auto;
+    overflow-x: hidden;
     height: 97vh;
+}
+
+.common::-webkit-scrollbar {
+  width: 20px;
+}
+
+.common::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
+.common::-webkit-scrollbar-thumb {
+  background-color: #d6dee1;
+  border-radius: 20px;
+  border: 6px solid transparent;
+  background-clip: content-box;
+}
+
+.common::-webkit-scrollbar-thumb:hover {
+  background-color: #a8bbbf;
 }
 
 .div1 {
@@ -87,6 +107,26 @@
         margin-top: 10px;
         grid-area: 2 / 1 / 3 / 2;
         width: calc(100vw - 20px);
+        overflow-x: hidden;
+    }
+
+    .main::-webkit-scrollbar {
+      width: 20px;
+    }
+    
+    .main::-webkit-scrollbar-track {
+      background-color: transparent;
+    }
+    
+    .main::-webkit-scrollbar-thumb {
+      background-color: #d6dee1;
+      border-radius: 20px;
+      border: 6px solid transparent;
+      background-clip: content-box;
+    }
+    
+    .main::-webkit-scrollbar-thumb:hover {
+      background-color: #a8bbbf;
     }
 
     .twoSectionsLayout {

--- a/components/main/main.js
+++ b/components/main/main.js
@@ -17,7 +17,7 @@ const Home = ({ children, mainStyle } = {}) => {
     return (
         <MainGrid
             className={styles.grid}
-            style={{ overflow: "auto", visibility: visible ? "visible" : "hidden" }}
+            style={{ visibility: visible ? "visible" : "hidden" }}
         >
             <CodeThemeProvider>
                 <Nav />

--- a/components/main/navbar.js
+++ b/components/main/navbar.js
@@ -19,46 +19,42 @@ const Dialog = ({ onDismiss, isOpen, label, children }) => (
     </DialogOverlay>
 )
 
+const labelProps = name => {
+    return { "aria-label": name, "title": name, name }
+}
+
 const NavInner = () => {
     const { changeMenuState, menuState } = useMenuState()
-
+    const iProps = { style: { margin: "5px 10px" }, side: "large" }
     return (
         <>
             <DivBg2 Component="nav" style={{ padding: "0" }} className={styles.nav}>
                 <div className={styles.navButtonsContainer}>
                     <SquareButton
-                        side="large"
                         onClick={() => changeMenuState("react")}
-                        aria-label="react menu"
-                        title="react menu"
-                        name="react menu"
+                        {...labelProps("react menu")}
+                        {...iProps}
                     >
                         <FaReact />
                     </SquareButton>
                     <SquareButton
-                        side="large"
                         onClick={() => changeMenuState("theme")}
-                        aria-label="theme menu"
-                        title="theme menu"
-                        name="theme menu"
+                        {...labelProps("theme menu")}
+                        {...iProps}
                     >
                         <MdSettings />
                     </SquareButton>
                     <SquareButton
-                        side="large"
                         href="https://github.com/mithi"
-                        aria-label="follow me on github"
-                        title="follow me on github"
-                        name="follow me on github"
+                        {...labelProps("follow me on github")}
+                        {...iProps}
                     >
                         <GoOctoface />
                     </SquareButton>
                     <SquareButton
-                        side="large"
                         href="https://ko-fi.com/minimithi"
-                        aria-label="buy me a coffee"
-                        title="buy me a coffee"
-                        name="buy me a coffee"
+                        {...labelProps("buy me a coffee")}
+                        {...iProps}
                     >
                         <BiCoffeeTogo />
                     </SquareButton>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "epic-react-exercises",
             "version": "0.1.0",
             "dependencies": {
                 "@bigheads/core": "^0.3.1",
@@ -1232,7 +1231,6 @@
                 "jest-resolve": "^26.6.2",
                 "jest-util": "^26.6.2",
                 "jest-worker": "^26.6.2",
-                "node-notifier": "^8.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
@@ -3371,7 +3369,6 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.1.2",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -4424,17 +4421,17 @@
             "integrity": "sha512-FeIuBzArONbAmKmZIsZIFGu/Gc9AVGlVeVbhCq+G2YIl6QkT0TDn2HKN/FMf1btXEB9kEmIuQf3/lBTVAbmFOg=="
         },
         "node_modules/elliptic": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-            "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
             "dependencies": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
                 "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "node_modules/elliptic/node_modules/bn.js": {
@@ -4664,8 +4661,7 @@
                 "esprima": "^4.0.1",
                 "estraverse": "^4.2.0",
                 "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
+                "optionator": "^0.8.1"
             },
             "bin": {
                 "escodegen": "bin/escodegen.js",
@@ -5603,7 +5599,6 @@
             "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-3.6.2.tgz",
             "integrity": "sha512-PMmybIGmIZVOb422NbUPIu919Rqm6MEKYyoOInExWdVFBsY+isbbu7/R60TZ+ru2eewLq3uTwntrYX04MxnAhg==",
             "dependencies": {
-                "@emotion/is-prop-valid": "^0.8.2",
                 "framesync": "^5.0.0",
                 "hey-listen": "^1.0.8",
                 "popmotion": "^9.1.0",
@@ -7337,7 +7332,6 @@
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^2.1.2",
                 "graceful-fs": "^4.2.4",
                 "jest-regex-util": "^26.0.0",
                 "jest-serializer": "^26.6.2",
@@ -9294,7 +9288,6 @@
                 "resolve-url-loader": "3.1.2",
                 "sass-loader": "10.0.5",
                 "schema-utils": "2.7.1",
-                "sharp": "0.26.2",
                 "stream-browserify": "3.0.0",
                 "style-loader": "1.2.1",
                 "styled-jsx": "3.3.2",
@@ -10338,9 +10331,6 @@
             "version": "1.23.0",
             "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
             "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-            "dependencies": {
-                "clipboard": "^2.0.0"
-            },
             "optionalDependencies": {
                 "clipboard": "^2.0.0"
             }
@@ -13602,8 +13592,7 @@
             "dependencies": {
                 "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0",
-                "watchpack-chokidar2": "^2.0.1"
+                "neo-async": "^2.5.0"
             },
             "optionalDependencies": {
                 "watchpack-chokidar2": "^2.0.1"
@@ -17678,17 +17667,17 @@
             "integrity": "sha512-FeIuBzArONbAmKmZIsZIFGu/Gc9AVGlVeVbhCq+G2YIl6QkT0TDn2HKN/FMf1btXEB9kEmIuQf3/lBTVAbmFOg=="
         },
         "elliptic": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-            "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
             "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
                 "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
             },
             "dependencies": {
                 "bn.js": {


### PR DESCRIPTION
Hi @mithi -- So I finally beautified the scrollbars for Windows (well, Chrome) this morning.  (Lol, I thought this was gonna be a ten-minute fix.... but nope! 🤦‍♂️)  Anyway, it was fun!  👍

# The "scrollbars bug" fix:

![image](https://user-images.githubusercontent.com/45280066/110672699-eb274500-819d-11eb-8238-24c4c78ca015.png)

And when the screen resizes, I took care of giving `.main` scrollbars in the `@media` section:

![image](https://user-images.githubusercontent.com/45280066/110677427-29733300-81a3-11eb-9af2-8923ffece225.png)

There was one tricky thing that took me a literal hour to figure out, btw:  In `main.js` in `MainGrid` you'd hardcoded `overflow=auto` which had been overriding the css that I'd been trying to set in `Style.module.css`.  Out of curiosity, was there a specific reason you'd hardcoded that there?   I needed to delete that bit or else this would happen:

![image](https://user-images.githubusercontent.com/45280066/110677294-ffba0c00-81a2-11eb-8b84-3829ab6a5066.png)

With the `overflow=auto` hardcode removed, it now looks like:

![image](https://user-images.githubusercontent.com/45280066/110682290-c1bfe680-81a8-11eb-9d0e-d3f223f3edd5.png)

But in Edge, it still looks awful.  I'd followed the below guide but it didn't work so I'm giving up on it.  Sorry, Edge people! 🤷

PS. It me a few tries to get it right, so if you do merge my PR, you'll probably want to do a "squash & merge".

---

**References:**

- https://dev.to/xtrp/how-to-create-a-beautiful-custom-scrollbar-for-your-site-in-plain-css-1mjg