### PR TITLE
(fix) Use _JSXStyle element instead of style

### DIFF
--- a/components/pretty-defaults/index.js
+++ b/components/pretty-defaults/index.js
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import Image from "next/image"
 import { useTheme } from "providers"
+import _JSXStyle from "styled-jsx/style"
 
 const MainGrid = ({ children, className, style }) => {
     const { bg1ClassName, bodyFont } = useTheme()
@@ -198,7 +199,7 @@ const RoundedImage = ({ src, width, height, alt, borderType, style }) => {
                 width={width}
                 quality={100}
             />
-            <style jsx global>{`
+            <_JSXStyle>{`
                 .border20percent {
                     border-radius: 20%;
                 }
@@ -208,7 +209,7 @@ const RoundedImage = ({ src, width, height, alt, borderType, style }) => {
                 .border25percent {
                     border-radius: 25%;
                 }
-            `}</style>
+            `}</_JSXStyle>
         </div>
     )
 }


### PR DESCRIPTION
The `<style jsx global>` tag is not properly transpiling to `_JSXStyle`, which blocks some of the exercises. Switching to `_JSXStyle` directly fixes the issue.

This change addresses the following issues: https://github.com/mithi/epic-react-exercises/issues/152, https://github.com/mithi/epic-react-exercises/issues/150, https://github.com/mithi/epic-react-exercises/issues/149, https://github.com/mithi/epic-react-exercises/issues/148.

 
### Error seen:
<img width="966" alt="Screen Shot 2023-04-17 at 1 57 23 PM" src="https://user-images.githubusercontent.com/1342734/232609098-c7c9f0da-d4f2-49f0-ba9f-64b7a5101ef6.png">

### With update: 
<img width="672" alt="Screen Shot 2023-04-17 at 1 56 58 PM" src="https://user-images.githubusercontent.com/1342734/232609940-ef246469-759a-43c7-8a48-19b8602a0c9a.png">


